### PR TITLE
Update Toronto (YYZ) office hours to 7:30pm

### DIFF
--- a/src/routes/yyz/+page.svelte
+++ b/src/routes/yyz/+page.svelte
@@ -1,7 +1,7 @@
 <h1>yyz</h1>
 <h2>Toronto, Ontario</h2>
 
-<h3>Fridays at 6:30pm</h3>
+<h3>Fridays at 7:30pm</h3>
 <p>
   view website here: <a href="https://officehours.bar">officehours.bar</a>
 </p>


### PR DESCRIPTION
## Summary
- Updates the Toronto (YYZ) office hours start time from 6:30pm to 7:30pm

🤖 Generated with [Claude Code](https://claude.com/claude-code)