### PR TITLE
Move Singapore to inactive

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,10 +20,6 @@
     { slug: 'ams', label: 'Amsterdam, NL' },
   ]);
 
-  const as = shuffle([
-    
-  ]);
-
   const inactive = shuffle([
     { slug: 'ord', label: 'Chicago, IL' },
     { slug: 'ber', label: 'Berlin, DE' },
@@ -44,14 +40,6 @@
     <h3>europe:</h3>
     <ul>
       {#each eu as { slug, label }}
-        <li><abbr title="{label}"><a href="{`/${slug}`}">{slug}</a></abbr></li>
-      {/each}
-    </ul>
-  </div>
-  <div id="as">
-    <h3>asia:</h3>
-    <ul>
-      {#each as as { slug, label }}
         <li><abbr title="{label}"><a href="{`/${slug}`}">{slug}</a></abbr></li>
       {/each}
     </ul>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,12 +21,13 @@
   ]);
 
   const as = shuffle([
-    { slug: 'sin', label: 'Singapore' },
+    
   ]);
 
   const inactive = shuffle([
     { slug: 'ord', label: 'Chicago, IL' },
     { slug: 'ber', label: 'Berlin, DE' },
+    { slug: 'sin', label: 'Singapore' },
   ]);
 </script>
 

--- a/src/routes/sin/+page.svelte
+++ b/src/routes/sin/+page.svelte
@@ -1,30 +1,14 @@
 <h1>sin</h1>
 <h2>Singapore, South-east Asia</h2>
 
-<em>Hi there, stranger. Wanna join us?</em>
+<p>formerly every second Wednesday of the month, at 7pm at Temasek Shophouse</p>
 
-<div class="info-green">
-  <p>Location: We're at Temasek Shophouse, near Dhoby Ghaut MRT station.</p>
-  <p>Time: every second Wednesday of the month, 7 PM,</p>
-  <p>Starting on 14 January 2026.</p>
-</div>
-
-<div>
+<div class="alert">
   <p>
-    Email Tony for more info at  tony [at] tonyshouse [dot] art
-  </p>
-  <p>But if Tony is unavailable for some reason, please contact 
-    <a href="https://x.com/kelbystrike">Kelvin on Twitter/X.</a>
-  </p>
-</div>
-
-<div class="info-blue">
-  <p>
-    Identifying mark (so you don't have to ask a
-    total stranger: "Is this Office Hours?" How mortifying.)
+    Singapore office hours are currently inactive.
   </p>
   <p>
-    Look for a white thermos flask that says GlucosCare.
-    (it's a gift from my parents, they struggle with diabetes).
+    If you want to take the responsibility of organizing Singapore office hours,
+    contact <a href="https://twitter.com/whiskeytuesday">@whiskeytuesday</a>
   </p>
 </div>


### PR DESCRIPTION
Singapore office hours are no longer active. 


- Moves Singapore out of the Asia active list,
- updates its page to match the Chicago (ord) inactive page style.
- deletes Asia list (since Singapore is the only representative of the continent, at the moment of writing)

<details>
<summary>my decision-making process</summary>

## Observations:

From January to May (2026), only one person showed up for office hours.

## Notes:

This has been an interesting experiment,  however if I were to apply the lens of Design Thinking: 

1. Is it desirable?
2. Is it viable? (re. tech)
3. is it feasible? (re. finances)

I think this effort requires more thoughtfulness, and clarity of intention, on my part. Back to the drawing board, it is!

## thoughts, after five months (and all of one attendee)

I think there are impediments to scaling it up. For example, in an extreme case, the managers of the venue likely would feel shocked if fifty people showed up for Office Hours, without anyone knowing anything beforehand, not even myself.

One person in attendance is manageable, however the faceless nature of the Internet - and the lack of a RSVP system to track expected attendance - makes my Office Hours a potential sitting duck, or an easy set-up for chaotic conditions to ripen.

I will take a break from Office Hours, and refine my ideas, having learnt something from the past five months.

Thank you, WhiskeyTuesday, for the platform and the opportunity. It's been fun!


</details>